### PR TITLE
CE-425 ParserUtil::sanitizeUrl() in Location::setUrl() adds unnecessa…

### DIFF
--- a/Entity/MailChimpNewsletter.php
+++ b/Entity/MailChimpNewsletter.php
@@ -12,6 +12,7 @@ namespace CampaignChain\Operation\MailChimpBundle\Entity;
 
 use CampaignChain\CoreBundle\Entity\Meta;
 use Doctrine\ORM\Mapping as ORM;
+use CampaignChain\CoreBundle\Util\ParserUtil;
 
 /**
  * @ORM\Entity
@@ -190,7 +191,7 @@ class MailChimpNewsletter extends Meta
      */
     public function setArchiveUrlLong($archiveUrlLong)
     {
-        $this->archiveUrlLong = $archiveUrlLong;
+        $this->archiveUrlLong = ParserUtil::sanitizeUrl($archiveUrlLong);
     }
 
     /**


### PR DESCRIPTION
…ry trailing slash that causes e.g. GoToWebinar links to not work
